### PR TITLE
Switch to Font Awesome icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@fortawesome/react-fontawesome": "^0.2.2",
         "daisyui": "^5.0.19",
         "framer-motion": "^12.12.1",
-        "lucide-react": "^0.511.0",
         "next": "15.3.0",
         "next-pwa": "^5.6.0",
         "next-themes": "^0.4.6",
@@ -6995,15 +6994,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/lucide-react": {
-      "version": "0.511.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.511.0.tgz",
-      "integrity": "sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@fortawesome/react-fontawesome": "^0.2.2",
     "daisyui": "^5.0.19",
     "framer-motion": "^12.12.1",
-    "lucide-react": "^0.511.0",
     "next": "15.3.0",
     "next-pwa": "^5.6.0",
     "next-themes": "^0.4.6",

--- a/src/app/components/DarkToggle.tsx
+++ b/src/app/components/DarkToggle.tsx
@@ -2,7 +2,8 @@
 
 import { useTheme } from 'next-themes';
 import { useEffect, useState } from 'react';
-import { Sun as SunIcon, Moon as MoonIcon, Laptop as SystemIcon } from 'lucide-react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSun, faMoon, faLaptop } from '@fortawesome/free-solid-svg-icons';
 
 const modes = ['light', 'dark', 'system'] as const;
 type Mode = typeof modes[number];
@@ -19,8 +20,9 @@ export default function DarkToggle() {
 
     const realTheme = theme === 'system' ? systemTheme : theme;
 
-    let Icon = realTheme === 'dark' ? MoonIcon : SunIcon;
-    if (theme === 'system') Icon = SystemIcon;
+    let icon = faSun;
+    if (realTheme === 'dark') icon = faMoon;
+    if (theme === 'system') icon = faLaptop;
 
     const handleClick = () => {
         const nextIndex = (modes.indexOf(theme as Mode) + 1) % modes.length;
@@ -33,7 +35,7 @@ export default function DarkToggle() {
             aria-label="Toggle theme"
             className="p-2 hover:opacity-80 transition"
         >
-            <Icon size={20} />
+            <FontAwesomeIcon icon={icon} size="lg" />
         </button>
     );
 }

--- a/src/app/components/LoadInputForm.tsx
+++ b/src/app/components/LoadInputForm.tsx
@@ -2,9 +2,9 @@
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
-    faCartFlatbed,
-    faCartShopping,
-    faBoxOpen,
+    faBarsStaggered,
+    faKitMedical,
+    faTrashCan,
 } from '@fortawesome/free-solid-svg-icons';
 
 export type LoadInputFormProps = {
@@ -30,8 +30,9 @@ export default function LoadInputForm({
                 <label className="label">
                     <span className="label-text text-lg flex items-center gap-2">
                         <FontAwesomeIcon
-                            icon={faCartFlatbed}
+                            icon={faBarsStaggered}
                             className="text-[var(--taupe-gray)]"
+                            title="Laundry Carts"
                         />
                         Laundry Carts
                     </span>
@@ -52,8 +53,9 @@ export default function LoadInputForm({
                 <label className="label">
                     <span className="label-text text-lg flex items-center gap-2">
                         <FontAwesomeIcon
-                            icon={faCartShopping}
+                            icon={faKitMedical}
                             className="text-[var(--taupe-gray)]"
+                            title="HMMS Carts"
                         />
                         HMMS Carts
                     </span>
@@ -74,8 +76,9 @@ export default function LoadInputForm({
                 <label className="label">
                     <span className="label-text text-lg flex items-center gap-2">
                         <FontAwesomeIcon
-                            icon={faBoxOpen}
+                            icon={faTrashCan}
                             className="text-[var(--taupe-gray)]"
+                            title="Bins"
                         />
                         Bins
                     </span>

--- a/src/app/components/LoadSummary.tsx
+++ b/src/app/components/LoadSummary.tsx
@@ -4,10 +4,10 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
     faTruck,
-    faTruckRampBox,
+    faDog,
     faTruckMoving,
+    faTriangleExclamation,
 } from '@fortawesome/free-solid-svg-icons';
-import { AlertTriangle } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { requiresSidewaysLoading } from '@/app/utils/loadLogic';
 
@@ -48,7 +48,10 @@ export default function LoadSummary({
             <h2 className="text-xl font-bold mb-2">Load Summary</h2>
             {showSidewaysBadge && (
                 <div className="alert alert-warning py-2 text-sm flex items-center gap-2">
-                    <AlertTriangle size={18} />
+                    <FontAwesomeIcon
+                        icon={faTriangleExclamation}
+                        title="Sideways Loading Required"
+                    />
                     <span>Sideways loading required</span>
                 </div>
             )}
@@ -65,7 +68,7 @@ export default function LoadSummary({
                     transition={{ duration: 0.3 }}
                     className={`alert ${fitsIn.pup ? 'alert-success' : 'alert-error'} py-2 text-sm flex items-center gap-2`}
                 >
-                    <FontAwesomeIcon icon={faTruckRampBox} />
+                    <FontAwesomeIcon icon={faDog} title="Pup Trailer" />
                     <span>Pup (max 25): {fitsIn.pup ? 'Fits' : 'Too Full'}</span>
                 </motion.div>
                 <motion.div
@@ -75,7 +78,7 @@ export default function LoadSummary({
                     transition={{ duration: 0.3, delay: 0.1 }}
                     className={`alert ${fitsIn['50ft'] ? 'alert-success' : 'alert-error'} py-2 text-sm flex items-center gap-2`}
                 >
-                    <FontAwesomeIcon icon={faTruckMoving} />
+                    <FontAwesomeIcon icon={faTruckMoving} title="50 ft Trailer" />
                     <span>50 ft (max 38): {fitsIn['50ft'] ? 'Fits' : 'Too Full'}</span>
                 </motion.div>
                 <motion.div
@@ -85,13 +88,13 @@ export default function LoadSummary({
                     transition={{ duration: 0.3, delay: 0.2 }}
                     className={`alert ${fitsIn.straight ? 'alert-success' : 'alert-error'} py-2 text-sm flex items-center gap-2`}
                 >
-                    <FontAwesomeIcon icon={faTruck} />
+                    <FontAwesomeIcon icon={faTruck} title="Straight Truck" />
                     <span>Straight Truck (max 20): {fitsIn.straight ? 'Fits' : 'Too Full'}</span>
                 </motion.div>
             </div>
 
             <div className={`mt-4 alert ${getRecommendationStyle(recommendation)} flex items-center gap-2`}>
-                <FontAwesomeIcon icon={faTruck} />
+                <FontAwesomeIcon icon={faTruck} title="Recommendation" />
                 <span>Recommended: {recommendation}</span>
             </div>
         </motion.div>

--- a/src/app/lib/fontawesome.ts
+++ b/src/app/lib/fontawesome.ts
@@ -1,6 +1,36 @@
 import { library } from '@fortawesome/fontawesome-svg-core';
-import { faTruck, faArrowRotateLeft, faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+import {
+    faTruck,
+    faArrowRotateLeft,
+    faInfoCircle,
+    faBarsStaggered,
+    faKitMedical,
+    faTrashCan,
+    faDog,
+    faTruckMoving,
+    faTriangleExclamation,
+    faSun,
+    faMoon,
+    faLaptop,
+} from '@fortawesome/free-solid-svg-icons';
 import { faCircleQuestion } from '@fortawesome/free-regular-svg-icons';
 import { faSpotify, faApple, faYoutube } from '@fortawesome/free-brands-svg-icons';
 
-library.add(faTruck, faArrowRotateLeft, faInfoCircle, faCircleQuestion, faSpotify, faApple, faYoutube);
+library.add(
+    faTruck,
+    faArrowRotateLeft,
+    faInfoCircle,
+    faBarsStaggered,
+    faKitMedical,
+    faTrashCan,
+    faDog,
+    faTruckMoving,
+    faTriangleExclamation,
+    faSun,
+    faMoon,
+    faLaptop,
+    faCircleQuestion,
+    faSpotify,
+    faApple,
+    faYoutube,
+);


### PR DESCRIPTION
## Summary
- migrate from Lucide to Font Awesome icons
- adjust trailer and cart icons for clarity
- clean up unused Lucide dependency

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6846c3d87fcc832abb6522b1ac121c80