### PR TITLE
Improve PWA support

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,11 +2,14 @@ import type { NextConfig } from 'next';
 
 const createPWAConfig = async (): Promise<NextConfig> => {
   const { default: withPWA } = await import('next-pwa');
+  const { default: runtimeCaching } = await import('next-pwa/cache');
 
   return withPWA({
     dest: 'public',
     register: true,
     skipWaiting: true,
+    runtimeCaching,
+    disable: process.env.NODE_ENV === 'development',
   })({
     experimental: {
       serverActions: {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,10 +1,10 @@
 {
   "name": "Trailer Load Planner",
-  "short_name": "Load Planner",
+  "short_name": "LoadPlanner",
   "start_url": "/",
   "display": "standalone",
-  "theme_color": "#0a0a0a",
-  "background_color": "#0a0a0a",
+  "theme_color": "#0f172a",
+  "background_color": "#ffffff",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
   description:
     "Easily calculate load options for Pup, 50 ft, and Straight Truck setups.",
   metadataBase: new URL("https://lplanner.vercel.app"),
-  manifest: "/manifest.webmanifest",
+  manifest: "/manifest.json",
   openGraph: {
     title: "Trailer Load Planner",
     description:

--- a/src/app/viewport.ts
+++ b/src/app/viewport.ts
@@ -1,7 +1,7 @@
 import type { Viewport } from 'next';
 
 export const viewport: Viewport = {
-  themeColor: '#0a0a0a', // Dark mode background
+  themeColor: '#0f172a',
   width: 'device-width',
   initialScale: 1,
   maximumScale: 1,


### PR DESCRIPTION
## Summary
- rename PWA manifest to `manifest.json`
- update manifest theme and background colors
- reference manifest in layout metadata
- change theme-color meta tag to match manifest
- enable runtime caching and dev-disable in `next-pwa`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_684764f0b810832a986b9da507553c3d